### PR TITLE
fixing case on sort order save where there are no records yet

### DIFF
--- a/wagtailorderable/models.py
+++ b/wagtailorderable/models.py
@@ -17,7 +17,7 @@ class Orderable(models.Model):
 
     def save(self, *args, **kwargs):
         if self.pk is None:
-            self.sort_order = self.__class__.objects.aggregate(Max('sort_order'))['sort_order__max'] + 1
+            self.sort_order = self.__class__.objects.aggregate(Max('sort_order'))['sort_order__max'] or 0 + 1
         super().save(*args, **kwargs)
 
     class Meta:


### PR DESCRIPTION
@rddesmond hardly worth the pull request but as I wanted a fork anyway... I found there's an issue where there are no records for obvious reasons you'll get
`TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'`
As (it seems) this lib supposes python3 and up I guessed a simple 'or 0' would be the most elegant fix.