### PR TITLE
operations order fix on sort order save

### DIFF
--- a/wagtailorderable/models.py
+++ b/wagtailorderable/models.py
@@ -17,7 +17,7 @@ class Orderable(models.Model):
 
     def save(self, *args, **kwargs):
         if self.pk is None:
-            self.sort_order = self.__class__.objects.aggregate(Max('sort_order'))['sort_order__max'] or 0 + 1
+            self.sort_order = (self.__class__.objects.aggregate(Max('sort_order'))['sort_order__max'] or 0) + 1
         super().save(*args, **kwargs)
 
     class Meta:


### PR DESCRIPTION
@rddesmond sorry :) I just checked and the parenthesis are necessary to ensure the right operations order - I had them in the version I quickly edited but not in the fork.  So I managed to end up needing to fix a fix which was of 3 characters length ;).  Anyway, now we've gone from 3 to 5.